### PR TITLE
Confirm before reopening settings when credentials are already set

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -519,6 +519,9 @@ const openSettings = () => {
   const token = localStorage.getItem('ynabToken') || '';
   const budgetId = localStorage.getItem('ynabBudgetId') || '';
   const syncSince = localStorage.getItem('ynabSyncSince') || defaultSyncSince();
+  if (token || budgetId) {
+    if (!confirm('Settings contain sensitive data (API token). Are you sure you want to show settings?')) return;
+  }
   settingsState.value.tomlText = buildToml(token, budgetId, syncSince);
   settingsState.value.error = '';
   settingsState.value.visible = true;


### PR DESCRIPTION
Prevent accidental exposure of sensitive data (YNAB API token) by prompting the user for confirmation before showing the settings modal if settings have already been configured.

https://claude.ai/code/session_01RUygtxhTWyuVMbk5dVPFcF